### PR TITLE
Use 7th stable version for FT in the release notes

### DIFF
--- a/catalogs/qhimm.xml
+++ b/catalogs/qhimm.xml
@@ -1696,7 +1696,7 @@ Battle Avatars Support</Description>
         <CompatibleGameVersions></CompatibleGameVersions>
         <PreviewImage>https://i.imgur.com/YquwKIl.png</PreviewImage>
         <ReleaseNotes>
-Requires 7th Heaven 2.9.9.72+
+Requires 7th Heaven 3.0.0+
 Fix color schemes not surviving save
 Undo color force in lieu of Reshade compatability
 Added Finishing Touch V2 battle view


### PR DESCRIPTION
Context of this PR: 2.9.9 versions were interim canary which are not meant to be used as baseline. Update the notation to mention instead the official next stable.