### PR TITLE
Updated qhimm.xml with new link for Bynyl soundtrack

### DIFF
--- a/catalogs/qhimm.xml
+++ b/catalogs/qhimm.xml
@@ -1220,7 +1220,7 @@ Fix steps playing while swimming in Junon</ReleaseNotes>
       <Author>Bynyl</Author>
       <Link>https://forums.qhimm.com/index.php?topic=18483.0</Link>
       <LatestVersion>
-        <Link>iros://GDrive/1BJ9e3GNYTXNdFmCz28OBPElzV4E6cmKT</Link>
+        <Link>iros://Url/https://cosmos.7thheaven.rocks/Bynyl_FF7_Soundtrack_Remake.iro</Link>
         <Version>0.57</Version>
         <ReleaseDate>2020-11-07</ReleaseDate>
         <PreviewImage>https://i.imgur.com/9ft52TX.jpeg</PreviewImage>


### PR DESCRIPTION
The previous google drive link did not work because of a virus check warning that require user input to initialize the download.