### PR TITLE
Update Nitpick to version 1.81

### DIFF
--- a/catalogs/qhimm.xml
+++ b/catalogs/qhimm.xml
@@ -2437,20 +2437,17 @@ Requires Enhanced Stock UI
       <Author>Kuraudo, Cae Lumen, Satsuki, Aavock, L@zar0, Dangarfield, Kaldarasha, Grimmy, Jusete</Author>
       <Link>https://forums.qhimm.com/index.php?topic=21345.0</Link>
       <LatestVersion>
-        <Link>iros://GDrive/10vR_a0jr_BINK1Q3g7gzNcpXyzIeWrIb</Link>
-        <Version>1.8</Version>
-        <ReleaseDate>2026-03-01</ReleaseDate>
+        <Link>iros://GDrive/1aHqd37DgK0blP_tMmRX5xS1PdDDKAxym</Link>
+        <Version>1.81</Version>
+        <ReleaseDate>2026-04-26</ReleaseDate>
         <CompatibleGameVersions>All</CompatibleGameVersions>
         <PreviewImage>https://i.imgur.com/9QHdwR7.jpeg</PreviewImage>
-        <ReleaseNotes>Added PS1-style options: Light up the World, Pixelback. Also, option to play music on new game screen.</ReleaseNotes>
-        <DownloadSize>100145</DownloadSize>
+        <ReleaseNotes>Added PS1-style options: Optic Blast, Light up the World, Pixelback, UWback. Added Midgar title screen background, attract mode credit backgrounds and fixed music on title screen. Added alternative world map.</ReleaseNotes>
+        <DownloadSize>126929</DownloadSize>
       </LatestVersion>
       <Name>Nitpick</Name>
       <Category>User Interface</Category>
-      <Description>This mod gives you access to some niche options, which fixes a few minor details, for example, Seventh Heaven bar sign, Midgar 5 truck label, District 5 gate number, Corel Prison sign, black materia shape, Red XIII's portrait, PS1-style tweaks and more.
-   -Requires SYW Unified Field Textures, SYW Unified Worldmap Textures, 60/30 FPS Gameplay
-   -Background fixes are not yet compatible with Cosmos Limit Break
-   -Light up the World not compatible with Cosmos Gaia</Description>
+      <Description>This mod gives you access to some niche options, which fixes a few minor details, for example, Seventh Heaven bar sign, Midgar 5 truck label, District 5 gate number, Corel Prison sign, black materia shape, Red XIII's portrait etc. It also offers a range of add-ons, including the option to change the background on the title screen and the credits screen, disc change screen homage. You can listen to music during the title screen, as well as enjoy PSX-style tweaks and more!</Description>
       <Tags>
         <string>Nitpick</string>
         <string>User Interface</string>


### PR DESCRIPTION
Hot feature: Eye texture hack fix (Optic Blast).

Adding PS1-style options: Optic Blast, Light up the World (vanilla), UWback. Added Midgar title screen background, attract mode credit backgrounds and fixed music on title screen. Added alternative world map.